### PR TITLE
Fix silverlight crash

### DIFF
--- a/Build.Packages.bat
+++ b/Build.Packages.bat
@@ -1,0 +1,2 @@
+@echo off
+powershell -NoProfile -ExecutionPolicy unrestricted -Command ".\Build\psake.ps1 .\Build\default.ps1 

--- a/Source/Plugins/Chill.Autofac/Content/Chill/DefaultChillContainer.cs
+++ b/Source/Plugins/Chill.Autofac/Content/Chill/DefaultChillContainer.cs
@@ -4,3 +4,7 @@ using Chill.Autofac;
 // This attribute defines which container will be used by default for this assembly
 
 [assembly: ChillContainer(typeof(AutofacChillContainer))]
+
+#if SILVERLIGHT
+[assembly: InternalsVisibleTo("Chill")]
+#endif

--- a/Source/Plugins/Chill.AutofacFakeItEasy/Content/Chill/DefaultChillContainer.cs
+++ b/Source/Plugins/Chill.AutofacFakeItEasy/Content/Chill/DefaultChillContainer.cs
@@ -4,3 +4,7 @@ using Chill.AutofacFakeItEasy;
 // This attribute defines which container will be used by default for this assembly
 
 [assembly: ChillContainer(typeof(AutofacFakeItEasyMockingContainer))]
+
+#if SILVERLIGHT
+[assembly: InternalsVisibleTo("Chill")]
+#endif

--- a/Source/Plugins/Chill.AutofacNSubstitute/Content/Chill/DefaultChillContainer.cs
+++ b/Source/Plugins/Chill.AutofacNSubstitute/Content/Chill/DefaultChillContainer.cs
@@ -4,3 +4,7 @@ using Chill.AutofacNSubstitute;
 // This attribute defines which container will be used by default for this assembly
 
 [assembly: ChillContainer(typeof(AutofacNSubstituteChillContainer))]
+
+#if SILVERLIGHT
+[assembly: InternalsVisibleTo("Chill")]
+#endif

--- a/Source/Plugins/Chill.Unity/Content/Chill/DefaultChillContainer.cs
+++ b/Source/Plugins/Chill.Unity/Content/Chill/DefaultChillContainer.cs
@@ -4,3 +4,7 @@ using Chill.Unity;
 // This attribute defines which container will be used by default for this assembly
 
 [assembly: ChillContainer(typeof(UnityChillContainer))]
+
+#if SILVERLIGHT
+[assembly: InternalsVisibleTo("Chill")]
+#endif

--- a/Source/Plugins/Chill.UnityNSubstitute/Content/Chill/DefaultChillContainer.cs
+++ b/Source/Plugins/Chill.UnityNSubstitute/Content/Chill/DefaultChillContainer.cs
@@ -4,3 +4,7 @@ using Chill.UnityNSubstitute;
 // This attribute defines which container will be used by default for this assembly
 
 [assembly: ChillContainer(typeof(UnityNSubstituteChillContainer))]
+
+#if SILVERLIGHT
+[assembly: InternalsVisibleTo("Chill")]
+#endif


### PR DESCRIPTION
Fixes the crash reported in #26 of the Silverlight unit test runner because Chill doesn't seem to have access to the test assembly. 