### PR TITLE
Resolving the same unregistered class twice returns the same object

### DIFF
--- a/Source/Core/Chill.Net45.Tests/TinyIocSpecs.cs
+++ b/Source/Core/Chill.Net45.Tests/TinyIocSpecs.cs
@@ -54,6 +54,11 @@ namespace Chill.Tests.CoreScenarios
                 The<CodeObject>().Should().NotBeNull();
             }
 
+            [Fact]
+            public void Then_resolving_concrete_type_twice_returns_the_same_object()
+            {
+                The<CodeObject>().Should().BeSameAs(The<CodeObject>());
+            }
         }
 
 

--- a/Source/Core/Chill.Net45.Tests/UnityChillContainerSpecs.cs
+++ b/Source/Core/Chill.Net45.Tests/UnityChillContainerSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.CodeDom;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
@@ -54,6 +55,12 @@ namespace Chill.Tests.CoreScenarios
                 The<ITestService>().TryMe().Returns(true);
                 The<ITestService>().TryMe().Should().BeTrue();
                 The<ITestService>().Received().TryMe();
+            }
+
+            [Fact]
+            public void Resolving_concrete_type_twice_returns_the_same_object()
+            {
+                The<CodeObject>().Should().BeSameAs(The<CodeObject>());
             }
         }
     }

--- a/Source/Core/Chill.Shared/TestBase.cs
+++ b/Source/Core/Chill.Shared/TestBase.cs
@@ -221,7 +221,14 @@ namespace Chill
         public T The<T>()
             where T : class
         {
-            return Container.Get<T>();
+            T value = Container.Get<T>();
+
+            if (!Container.IsRegistered<T>())
+            {
+                Container.Set(value);
+            }
+
+            return value;
         }
 
         /// <summary>


### PR DESCRIPTION
(where it's supported)

Resolves #46 