### PR TITLE
[WIP] Alternative test base class created for really async specs (like xUnit async specs)

### DIFF
--- a/Source/Core/Chill.Net40.Tests/Chill.Net40.Tests.csproj
+++ b/Source/Core/Chill.Net40.Tests/Chill.Net40.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -21,7 +22,8 @@
     <TestProjectType>CodedUITest</TestProjectType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NuGetPackageImportStamp>d09a61ba</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -152,6 +154,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/Core/Chill.Net40.Tests/packages.config
+++ b/Source/Core/Chill.Net40.Tests/packages.config
@@ -9,4 +9,5 @@
   <package id="NSubstitute" version="1.7.2.0" targetFramework="net40" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net40" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net40" />
 </packages>

--- a/Source/Core/Chill.Net45.Tests/Chill.Net45.Tests.csproj
+++ b/Source/Core/Chill.Net45.Tests/Chill.Net45.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -14,7 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NuGetPackageImportStamp>31cf9ff6</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -111,6 +113,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/Core/Chill.Net45.Tests/packages.config
+++ b/Source/Core/Chill.Net45.Tests/packages.config
@@ -8,4 +8,5 @@
   <package id="Unity" version="3.5.1404.0" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/Source/Core/Chill.Shared/AsyncTestContext.cs
+++ b/Source/Core/Chill.Shared/AsyncTestContext.cs
@@ -1,0 +1,884 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Chill
+{
+    internal static class TaskFromResult
+    {
+        public static Task<TResult> Create<TResult>(TResult result)
+        {
+#if NET45
+            return Task.FromResult(result);
+#else
+            var taskCompletionSource = new TaskCompletionSource<TResult>();
+            taskCompletionSource.SetResult(result);
+            return taskCompletionSource.Task;
+#endif
+        }
+    }
+
+    public static class AsyncTestExtensions
+    {
+        public static void Given(this IAsyncTestContext context, Action given)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            context.Given(() =>
+            {
+                given();
+                return TaskFromResult.Create(false);
+            });
+        }
+
+        public static void Given<TSubject>(
+            this IAsyncTestContextWithSubject<TSubject> context,
+            Func<Func<TSubject>, Task<TSubject>> given)
+            where TSubject : class
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            context.Given(async oldSubjectFactory =>
+            {
+                TSubject subject = await given(oldSubjectFactory);
+                return () => subject;
+            });
+        }
+
+        public static void Given<TSubject>(
+            this IAsyncTestContextWithSubject<TSubject> context,
+            Func<Func<TSubject>, Task> given)
+            where TSubject : class
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            context.Given(async oldSubjectFactory =>
+            {
+                await given(oldSubjectFactory);
+                return oldSubjectFactory;
+            });
+        }
+
+        public static void Given<TSubject>(
+            this IAsyncTestContextWithSubject<TSubject> context,
+            Func<Task<Func<TSubject>>> given)
+            where TSubject : class
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            context.Given(_ => given());
+        }
+
+        public static void Given<TSubject>(
+            this IAsyncTestContextWithSubject<TSubject> context,
+            Func<Task<TSubject>> given)
+            where TSubject : class
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            context.Given(async _ =>
+            {
+                TSubject subject = await given();
+                return () => subject;
+            });
+        }
+
+        public static void Given<TSubject>(
+            this IAsyncTestContextWithSubject<TSubject> context,
+            Func<Task> given)
+            where TSubject : class
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            context.Given(async oldSubjectFactory =>
+            {
+                await given();
+                return oldSubjectFactory;
+            });
+        }
+
+        public static void Given<TSubject>(
+            this IAsyncTestContextWithSubject<TSubject> context,
+            Func<Func<TSubject>, Func<TSubject>> given)
+            where TSubject : class
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            context.Given(oldSubjectFactory => TaskFromResult.Create(given(oldSubjectFactory)));
+        }
+
+        public static void Given<TSubject>(
+            this IAsyncTestContextWithSubject<TSubject> context,
+            Func<Func<TSubject>, TSubject> given)
+            where TSubject : class
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            context.Given(oldSubjectFactory =>
+            {
+                TSubject subject = given(oldSubjectFactory);
+                return TaskFromResult.Create<Func<TSubject>>(() => subject);
+            });
+        }
+
+        public static void Given<TSubject>(
+            this IAsyncTestContextWithSubject<TSubject> context,
+            Action<Func<TSubject>> given)
+            where TSubject : class
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            context.Given(oldSubjectFactory =>
+            {
+                given(oldSubjectFactory);
+                return TaskFromResult.Create(oldSubjectFactory);
+            });
+        }
+
+        public static void Given<TSubject>(
+            this IAsyncTestContextWithSubject<TSubject> context,
+            Func<Func<TSubject>> given)
+            where TSubject : class
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            context.Given(_ => TaskFromResult.Create(given()));
+        }
+
+        public static void Given<TSubject>(
+            this IAsyncTestContextWithSubject<TSubject> context,
+            Func<TSubject> given)
+            where TSubject : class
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            context.Given(_ =>
+            {
+                TSubject subject = given();
+                return TaskFromResult.Create<Func<TSubject>>(() => subject);
+            });
+        }
+
+        public static void Given<TSubject>(
+            this IAsyncTestContextWithSubject<TSubject> context,
+            Action given)
+            where TSubject : class
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            context.Given(oldSubjectFactory =>
+            {
+                given();
+                return TaskFromResult.Create(oldSubjectFactory);
+            });
+        }
+
+        public static void When(this IAsyncTestContextWithoutResult context, Action when)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (when == null)
+            {
+                throw new ArgumentNullException(nameof(when));
+            }
+
+            context.When(() =>
+            {
+                when();
+                return TaskFromResult.Create(false);
+            });
+        }
+
+        public static void When<TResult>(this IAsyncTestContext<TResult> context, Func<TResult> when)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (when == null)
+            {
+                throw new ArgumentNullException(nameof(when));
+            }
+
+            context.When(() => TaskFromResult.Create(when()));
+        }
+    }
+
+    public interface IAsyncTestContext
+    {
+        void Given(Func<Task> given);
+    }
+
+    public interface IAsyncTestContextWithoutResult
+    {
+        void When(Func<Task> when);
+    }
+
+    public interface IAsyncTestContext<TResult> : IAsyncTestContext
+    {
+        void When(Func<Task<TResult>> when);
+    }
+
+    public interface IAsyncTestContextWithSubject<TSubject> : IAsyncTestContext
+        where TSubject : class
+    {
+        void Given(Func<Func<TSubject>, Task<Func<TSubject>>> given);
+    }
+
+    public interface IAsyncTestContextWithSubject<TSubject, TResult> :
+        IAsyncTestContextWithSubject<TSubject>,
+        IAsyncTestContext<TResult>
+        where TSubject : class
+    {
+    }
+
+    /// <summary>
+    /// Allows definition and execution of <c>Given</c> and <c>When</c> in really async tests
+    /// that follow the BDD style GivenWhenThen approach.
+    /// For tests that have no subject and no result.
+    /// </summary>
+    public sealed class AsyncTestContext : IAsyncTestContext, IAsyncTestContextWithoutResult
+    {
+        private readonly List<Func<Task>> givens = new List<Func<Task>>();
+        private Func<Task> when;
+        private bool areGivensExecuted;
+        private bool isWhenExecuted;
+
+        public async Task ExecuteGiven()
+        {
+            if (areGivensExecuted)
+            {
+                throw new InvalidOperationException("Givens have already been executed.");
+            }
+
+            areGivensExecuted = true;
+
+            foreach (Func<Task> given in givens)
+            {
+                Task task = given();
+
+                if (task == null)
+                {
+                    throw new InvalidOperationException("A Given delegate returned null task.");
+                }
+
+                await task;
+            }
+        }
+
+        public async Task ExecuteWhen()
+        {
+            if (when == null)
+            {
+                throw new InvalidOperationException("Each test class must have a When method call.");
+            }
+
+            if (!areGivensExecuted)
+            {
+                await ExecuteGiven();
+            }
+
+            if (isWhenExecuted)
+            {
+                throw new InvalidOperationException("When has already been executed.");
+            }
+
+            isWhenExecuted = true;
+
+            Task task = when();
+
+            if (task == null)
+            {
+                throw new InvalidOperationException("The When delegate returned null task.");
+            }
+
+            await task;
+        }
+
+        public void Given(Func<Task> given)
+        {
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            givens.Add(given);
+        }
+
+        public void When(Func<Task> when)
+        {
+            if (when == null)
+            {
+                throw new ArgumentNullException(nameof(when));
+            }
+
+            if (this.when != null)
+            {
+                throw new InvalidOperationException("Each test class can have only one When method call.");
+            }
+
+            this.when = when;
+        }
+    }
+
+    /// <summary>
+    /// Allows definition and execution of <c>Given</c> and <c>When</c> in really async tests
+    /// that follow the BDD style GivenWhenThen approach.
+    /// For tests that have result but no subject.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    public sealed class AsyncTestContext<TResult> : IAsyncTestContext<TResult>
+    {
+        private readonly List<Func<Task>> givens = new List<Func<Task>>();
+        private Func<Task<TResult>> when;
+        private bool areGivensExecuted;
+        private bool isWhenExecuted;
+
+        public async Task ExecuteGiven()
+        {
+            if (areGivensExecuted)
+            {
+                throw new InvalidOperationException("Givens have already been executed.");
+            }
+
+            areGivensExecuted = true;
+
+            foreach (Func<Task> given in givens)
+            {
+                Task task = given();
+
+                if (task == null)
+                {
+                    throw new InvalidOperationException("A Given delegate returned null task.");
+                }
+
+                await task;
+            }
+        }
+
+        public async Task<TResult> ExecuteWhen()
+        {
+            if (when == null)
+            {
+                throw new InvalidOperationException("Each test class must have a When method call.");
+            }
+
+            if (!areGivensExecuted)
+            {
+                await ExecuteGiven();
+            }
+
+            if (isWhenExecuted)
+            {
+                throw new InvalidOperationException("When has already been executed.");
+            }
+
+            isWhenExecuted = true;
+
+            Task<TResult> task = when();
+
+            if (task == null)
+            {
+                throw new InvalidOperationException("The When delegate returned null task.");
+            }
+
+            return await task;
+        }
+
+        public void Given(Func<Task> given)
+        {
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            givens.Add(given);
+        }
+
+        public void When(Func<Task<TResult>> when)
+        {
+            if (when == null)
+            {
+                throw new ArgumentNullException(nameof(when));
+            }
+
+            if (this.when != null)
+            {
+                throw new InvalidOperationException("Each test class can have only one When method call.");
+            }
+
+            this.when = when;
+        }
+    }
+
+    /// <summary>
+    /// Allows definition and execution of <c>Given</c> and <c>When</c> in really async tests
+    /// that follow the BDD style GivenWhenThen approach.
+    /// For tests that have subject but no result.
+    /// </summary>
+    /// <typeparam name="TSubject">The type of the subject.</typeparam>
+    public sealed class AsyncTestContextWithSubject<TSubject> :
+        IAsyncTestContextWithSubject<TSubject>,
+        IAsyncTestContextWithoutResult
+        where TSubject : class
+    {
+        private readonly TestBase test;
+
+        private readonly List<Func<Func<TSubject>, Task<Func<TSubject>>>> givens =
+            new List<Func<Func<TSubject>, Task<Func<TSubject>>>>();
+
+        private TSubject subject;
+        private bool areGivensExecuted;
+        private Func<TSubject, Task> when;
+        private bool isWhenExecuted;
+
+        public AsyncTestContextWithSubject(TestBase test)
+        {
+            if (test == null)
+            {
+                throw new ArgumentNullException(nameof(test));
+            }
+
+            this.test = test;
+        }
+
+        public async Task<TSubject> ExecuteGiven()
+        {
+            if (areGivensExecuted)
+            {
+                throw new InvalidOperationException("Givens have already been executed.");
+            }
+
+            areGivensExecuted = true;
+
+            Func<TSubject> currentSubjectFactory = () =>
+            {
+                if (!test.Container.IsRegistered<TSubject>())
+                {
+                    test.Container.RegisterType<TSubject>();
+                }
+
+                return test.Container.Get<TSubject>();
+            };
+
+            foreach (Func<Func<TSubject>, Task<Func<TSubject>>> given in givens)
+            {
+                Task<Func<TSubject>> task = given(currentSubjectFactory);
+
+                if (task == null)
+                {
+                    throw new InvalidOperationException("A Given delegate returned null task.");
+                }
+
+                currentSubjectFactory = await task;
+
+                if (currentSubjectFactory == null)
+                {
+                    throw new InvalidOperationException("A Given delegate produced null subject factory delegate.");
+                }
+            }
+
+            subject = currentSubjectFactory();
+
+            if (subject == null)
+            {
+                throw new InvalidOperationException("A Given delegate produced null subject.");
+            }
+
+            if (!test.Container.IsRegistered<TSubject>())
+            {
+                test.Container.Set(subject);
+            }
+
+            return subject;
+        }
+
+        public async Task ExecuteWhen()
+        {
+            if (when == null)
+            {
+                throw new InvalidOperationException("Each test class must have a When method call.");
+            }
+
+            if (!areGivensExecuted)
+            {
+                await ExecuteGiven();
+            }
+
+            if (isWhenExecuted)
+            {
+                throw new InvalidOperationException("When has already been executed.");
+            }
+
+            isWhenExecuted = true;
+
+            Task task = when(subject);
+
+            if (task == null)
+            {
+                throw new InvalidOperationException("The When delegate returned null task.");
+            }
+
+            await task;
+        }
+
+        public void Given(Func<Func<TSubject>, Task<Func<TSubject>>> given)
+        {
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            givens.Add(given);
+        }
+
+        public void Given(Func<Task> given)
+        {
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            givens.Add(async subjectFactory =>
+            {
+                await given();
+                return subjectFactory;
+            });
+        }
+
+        public void When(Func<TSubject, Task> when)
+        {
+            if (when == null)
+            {
+                throw new ArgumentNullException(nameof(when));
+            }
+
+            if (this.when != null)
+            {
+                throw new InvalidOperationException("Each test class can have only one When method call.");
+            }
+
+            this.when = when;
+        }
+
+        public void When(Func<Task> when)
+        {
+            if (when == null)
+            {
+                throw new ArgumentNullException(nameof(when));
+            }
+
+            When(_ => when());
+        }
+
+        public void When(Action<TSubject> when)
+        {
+            if (when == null)
+            {
+                throw new ArgumentNullException(nameof(when));
+            }
+
+            When(subject =>
+            {
+                when(subject);
+                return TaskFromResult.Create(false);
+            });
+        }
+
+        public void When(Action when)
+        {
+            if (when == null)
+            {
+                throw new ArgumentNullException(nameof(when));
+            }
+
+            When(_ =>
+            {
+                when();
+                return TaskFromResult.Create(false);
+            });
+        }
+    }
+
+    /// <summary>
+    /// Allows definition and execution of <c>Given</c> and <c>When</c> in really async tests
+    /// that follow the BDD style GivenWhenThen approach.
+    /// For tests that have result but no subject.
+    /// </summary>
+    /// <typeparam name="TSubject">The type of the subject.</typeparam>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    public sealed class AsyncTestContextWithSubject<TSubject, TResult> :
+        IAsyncTestContextWithSubject<TSubject>,
+        IAsyncTestContext<TResult>
+        where TSubject : class
+    {
+        private readonly TestBase test;
+
+        private readonly List<Func<Func<TSubject>, Task<Func<TSubject>>>> givens =
+            new List<Func<Func<TSubject>, Task<Func<TSubject>>>>();
+
+        private TSubject subject;
+        private bool areGivensExecuted;
+        private Func<TSubject, Task<TResult>> when;
+        private bool isWhenExecuted;
+
+        public AsyncTestContextWithSubject(TestBase test)
+        {
+            if (test == null)
+            {
+                throw new ArgumentNullException(nameof(test));
+            }
+
+            this.test = test;
+        }
+
+        public async Task<TSubject> ExecuteGiven()
+        {
+            if (areGivensExecuted)
+            {
+                throw new InvalidOperationException("Givens have already been executed.");
+            }
+
+            areGivensExecuted = true;
+
+            Func<TSubject> currentSubjectFactory = () =>
+            {
+                if (!test.Container.IsRegistered<TSubject>())
+                {
+                    test.Container.RegisterType<TSubject>();
+                }
+
+                return test.Container.Get<TSubject>();
+            };
+
+            foreach (Func<Func<TSubject>, Task<Func<TSubject>>> given in givens)
+            {
+                Task<Func<TSubject>> task = given(currentSubjectFactory);
+
+                if (task == null)
+                {
+                    throw new InvalidOperationException("A Given delegate returned null task.");
+                }
+
+                currentSubjectFactory = await task;
+
+                if (currentSubjectFactory == null)
+                {
+                    throw new InvalidOperationException("A Given delegate produced null subject factory delegate.");
+                }
+            }
+
+            subject = currentSubjectFactory();
+
+            if (subject == null)
+            {
+                throw new InvalidOperationException("A Given delegate produced null subject.");
+            }
+
+            if (!test.Container.IsRegistered<TSubject>())
+            {
+                test.Container.Set(subject);
+            }
+
+            return subject;
+        }
+
+        public async Task<TResult> ExecuteWhen()
+        {
+            if (when == null)
+            {
+                throw new InvalidOperationException("Each test class must have a When method call.");
+            }
+
+            if (!areGivensExecuted)
+            {
+                await ExecuteGiven();
+            }
+
+            if (isWhenExecuted)
+            {
+                throw new InvalidOperationException("When has already been executed.");
+            }
+
+            isWhenExecuted = true;
+
+            Task<TResult> task = when(subject);
+
+            if (task == null)
+            {
+                throw new InvalidOperationException("The When delegate returned null task.");
+            }
+
+            return await task;
+        }
+
+        public void Given(Func<Func<TSubject>, Task<Func<TSubject>>> given)
+        {
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            givens.Add(given);
+        }
+
+        public void Given(Func<Task> given)
+        {
+            if (given == null)
+            {
+                throw new ArgumentNullException(nameof(given));
+            }
+
+            givens.Add(async subjectFactory =>
+            {
+                await given();
+                return subjectFactory;
+            });
+        }
+
+        public void When(Func<TSubject, Task<TResult>> when)
+        {
+            if (when == null)
+            {
+                throw new ArgumentNullException(nameof(when));
+            }
+
+            if (this.when != null)
+            {
+                throw new InvalidOperationException("Each test class can have only one When method call.");
+            }
+
+            this.when = when;
+        }
+
+        public void When(Func<Task<TResult>> when)
+        {
+            if (when == null)
+            {
+                throw new ArgumentNullException(nameof(when));
+            }
+
+            When(_ => when());
+        }
+
+        public void When(Func<TSubject, TResult> when)
+        {
+            if (when == null)
+            {
+                throw new ArgumentNullException(nameof(when));
+            }
+
+            When(subject => TaskFromResult.Create(when(subject)));
+        }
+
+        public void When(Func<TResult> when)
+        {
+            if (when == null)
+            {
+                throw new ArgumentNullException(nameof(when));
+            }
+
+            When(_ => TaskFromResult.Create(when()));
+        }
+    }
+}

--- a/Source/Core/Chill.Shared/Chill.Shared.projitems
+++ b/Source/Core/Chill.Shared/Chill.Shared.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>29cd0883-250a-4121-a344-1377e99e3886</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Chill.Shared</Import_RootNamespace>
+    <Import_RootNamespace>Chill</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AssemblyTypeResolver.cs" />
@@ -17,6 +17,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DefaultChillContainerInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GivenSubject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AsyncTestContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GivenWhenThen.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IAutoMother.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IChillContainer.cs" />
@@ -28,6 +29,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)StateBuilders\StoreStateBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StateBuilders\StoreStateBuilderExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TaskExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SyncTestBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestFor.cs" />
   </ItemGroup>

--- a/Source/Core/Chill.Shared/GivenWhenThen.cs
+++ b/Source/Core/Chill.Shared/GivenWhenThen.cs
@@ -9,7 +9,7 @@ namespace Chill
     /// will be. 
     /// </summary>
     /// <typeparam name="TResult">The type of the result that you expect from your tests</typeparam>
-    public abstract class GivenWhenThen<TResult> : TestBase
+    public abstract class GivenWhenThen<TResult> : SyncTestBase
     {
         private Func<TResult> whenAction;
         private TResult result;
@@ -27,7 +27,7 @@ namespace Chill
 
         /// <summary>
         /// The action that triggers the actual test. This can be used in combination with deffered execution and fluent assertions 
-        /// to detect exceptions, if you don't wnat to use the <see cref="TestBase.CaughtException"/>
+        /// to detect exceptions, if you don't wnat to use the <see cref="SyncTestBase.CaughtException"/>
         /// </summary>
         public Func<TResult> WhenAction
         {
@@ -102,13 +102,13 @@ namespace Chill
     /// Baseclass for tests that follow the BDD style GivenWhenThen approach, but do not have 
     /// a fixed subject. This class does not use a predefined subject. 
     /// </summary>
-    public abstract class GivenWhenThen : TestBase
+    public abstract class GivenWhenThen : SyncTestBase
     {
         private Action whenAction;
 
         /// <summary>
         /// The action that triggers the actual test. This can be used in combination with deffered execution and fluent assertions 
-        /// to detect exceptions, if you don't wnat to use the <see cref="TestBase.CaughtException"/>
+        /// to detect exceptions, if you don't wnat to use the <see cref="SyncTestBase.CaughtException"/>
         /// </summary>
         public Action WhenAction
         {

--- a/Source/Core/Chill.Shared/SyncTestBase.cs
+++ b/Source/Core/Chill.Shared/SyncTestBase.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Chill.StateBuilders;
+
+namespace Chill
+{
+    /// <summary>
+    /// Base class for all Chill tests except <see cref="AsyncTest" />. This baseclass set's up your automocking container. 
+    /// 
+    /// It also has a convenient method TriggerTest you can call that will trigger an async test func
+    /// and capture any exceptions that might have occurred. 
+    /// </summary>
+    public abstract partial class SyncTestBase : TestBase
+    {
+        /// <summary>
+        /// Should the test execution start immediately on the When method or should execution be deffered until needed. 
+        /// </summary>
+        protected bool DefferedExecution { get; set; }
+    
+        private bool testTriggered;
+
+        /// <summary>
+        /// Any exception that might be thrown in the course of executing the When Method. Note, this property is often used
+        /// in conjunction with deffered excecution. 
+        /// </summary>
+        protected Exception CaughtException
+        {
+            get
+            {
+                EnsureTestTriggered(expectExceptions: true);
+                return caughtException;
+            }
+            set { caughtException = value; }
+        }
+
+
+        private Exception caughtException;
+
+        /// <summary>
+        /// Method that ensures that the test has actually been triggered. 
+        /// </summary>
+        /// <param name="expectExceptions"></param>
+        protected internal void EnsureTestTriggered(bool expectExceptions)
+        {
+            if (!testTriggered)
+            {
+                testTriggered = true;
+                TriggerTest(expectExceptions);
+            }
+        }
+
+        /// <summary>
+        /// Method that can be overriden to trigger the actual test
+        /// </summary>
+        /// <param name="expectExceptions"></param>
+        internal virtual void TriggerTest(bool expectExceptions)
+        {
+        }
+
+        internal void TriggerTest(Action testAction, bool expectExceptions)
+        {
+            if (expectExceptions)
+            {
+                try
+                {
+                    testAction();
+                }
+                catch (AggregateException ex)
+                {
+                    CaughtException = ex.GetBaseException();
+                }
+                catch (Exception ex)
+                {
+                    CaughtException = ex;
+                }
+                finally
+                {
+                    if (expectExceptions && CaughtException == null)
+                        throw new InvalidOperationException("Expected exception but no exception was thrown");
+                }
+            }
+            else
+            {
+                testAction();
+            }
+        }
+    }
+}

--- a/Source/Core/Chill.Shared/TestFor.cs
+++ b/Source/Core/Chill.Shared/TestFor.cs
@@ -9,7 +9,7 @@ namespace Chill
     /// the <see cref="BuildSubject"/> method. 
     /// </summary>
     /// <typeparam name="TSubject">The type of the subject you're testing. </typeparam>
-    public abstract class TestFor<TSubject> : TestBase
+    public abstract class TestFor<TSubject> : SyncTestBase
         where TSubject : class
     {
         private Func<IChillContainer, TSubject> subjectFactory;

--- a/Source/Core/Chill.Tests.Shared/AsyncTestSpecs.cs
+++ b/Source/Core/Chill.Tests.Shared/AsyncTestSpecs.cs
@@ -1,0 +1,326 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Chill.Tests.Shared
+{
+    namespace AsyncTestSpecs
+    {
+        public class When_there_is_no_subject_and_no_result : TestBase
+        {
+            private readonly AsyncTestContext test = new AsyncTestContext();
+            private BlockingCollection<int> sideEffects;
+
+            public When_there_is_no_subject_and_no_result()
+            {
+                test.Given(async () =>
+                {
+                    sideEffects = new BlockingCollection<int>();
+
+#if NET45
+                    await Task.Delay(10);
+#else
+                    await TaskEx.Delay(10);
+#endif
+                });
+
+                test.When(async () =>
+                {
+                    foreach (int key in Enumerable.Range(0, 1000))
+                    {
+#if NET45
+                        await Task.Delay(10);
+#else
+                        await TaskEx.Delay(10);                            
+#endif
+                        sideEffects.Add(key);
+                    }
+                });
+            }
+
+            [Fact]
+            public async void Then_it_should_execute_asynchronously()
+            {
+                await test.ExecuteGiven();
+                await test.ExecuteWhen();
+                sideEffects.Should().HaveCount(1000);
+            }
+        }
+
+        public class When_there_is_result_but_no_subject : TestBase
+        {
+            private readonly AsyncTestContext<string> test = new AsyncTestContext<string>();
+            private BlockingCollection<int> sideEffects;
+
+            public When_there_is_result_but_no_subject()
+            {
+                test.Given(async () =>
+                {
+                    sideEffects = new BlockingCollection<int>();
+
+#if NET45
+                    await Task.Delay(10);
+#else
+                    await TaskEx.Delay(10);
+#endif
+                });
+
+                test.When(async () =>
+                {
+                    foreach (int key in Enumerable.Range(0, 1000))
+                    {
+#if NET45
+                        await Task.Delay(10);
+#else
+                        await TaskEx.Delay(10);
+#endif
+                        sideEffects.Add(key);
+                    }
+
+                    return "DONE";
+                });
+            }
+
+            [Fact]
+            public async void Then_it_should_execute_asynchronously()
+            {
+                await test.ExecuteGiven();
+                await test.ExecuteWhen();
+                sideEffects.Should().HaveCount(1000);
+            }
+
+            [Fact]
+            public async void Then_it_should_return_result()
+            {
+                await test.ExecuteGiven();
+                string result = await test.ExecuteWhen();
+                result.Should().Be("DONE");
+            }
+        }
+
+        public class When_there_is_subject_but_no_result : TestBase
+        {
+            private readonly AsyncTestContextWithSubject<Subject> test;
+            private BlockingCollection<int> sideEffects;
+            private Subject oldSubject1;
+            private Subject oldSubject2;
+            private Subject whenSubject;
+
+            public When_there_is_subject_but_no_result()
+            {
+                test = new AsyncTestContextWithSubject<Subject>(this);
+
+                test.Given(async getOldSubject =>
+                {
+                    oldSubject1 = getOldSubject();
+                    sideEffects = new BlockingCollection<int>();
+
+#if NET45
+                    await Task.Delay(10);
+#else
+                    await TaskEx.Delay(10);
+#endif
+
+                    return () => new Subject("SUBJ1");
+                });
+
+                test.Given(getOldSubject =>
+                {
+                    oldSubject2 = getOldSubject();
+                    return () => new Subject("SUBJ2");
+                });
+
+                test.When(async subject =>
+                {
+                    whenSubject = subject;
+
+                    foreach (int key in Enumerable.Range(0, 1000))
+                    {
+#if NET45
+                        await Task.Delay(10);
+#else
+                        await TaskEx.Delay(10);
+#endif
+                        sideEffects.Add(key);
+                    }
+                });
+            }
+
+            [Fact]
+            public async void Then_it_should_execute_asynchronously()
+            {
+                await test.ExecuteGiven();
+                await test.ExecuteWhen();
+
+                sideEffects.Should().HaveCount(1000);
+            }
+
+            [Fact]
+            public async void Then_it_should_have_subject_from_the_last_given()
+            {
+                Subject subject = await test.ExecuteGiven();
+                await test.ExecuteWhen();
+
+                subject.Should().NotBeNull();
+                subject.Value.Should().Be("SUBJ2");
+            }
+
+            [Fact]
+            public async void Then_the_first_given_should_receive_subject_factory_building_default_subject()
+            {
+                await test.ExecuteGiven();
+                await test.ExecuteWhen();
+
+                oldSubject1.Should().NotBeNull();
+                oldSubject1.Value.Should().Be(string.Empty);
+            }
+
+            [Fact]
+            public async void Then_the_second_given_should_receive_subject_factory_from_the_first_given()
+            {
+                await test.ExecuteGiven();
+                await test.ExecuteWhen();
+
+                oldSubject2.Should().NotBeNull();
+                oldSubject2.Value.Should().Be("SUBJ1");
+            }
+
+            [Fact]
+            public async void Then_the_when_should_receive_subject_from_the_last_given()
+            {
+                await test.ExecuteGiven();
+                await test.ExecuteWhen();
+
+                whenSubject.Should().NotBeNull();
+                whenSubject.Value.Should().Be("SUBJ2");
+            }
+        }
+
+        public class When_there_is_subject_and_result : TestBase
+        {
+            private readonly AsyncTestContextWithSubject<Subject, string> test;
+            private BlockingCollection<int> sideEffects;
+            private Subject oldSubject1;
+            private Subject oldSubject2;
+            private Subject whenSubject;
+
+            public When_there_is_subject_and_result()
+            {
+                test = new AsyncTestContextWithSubject<Subject, string>(this);
+
+                test.Given(async getOldSubject =>
+                {
+                    oldSubject1 = getOldSubject();
+                    sideEffects = new BlockingCollection<int>();
+
+#if NET45
+                    await Task.Delay(10);
+#else
+                    await TaskEx.Delay(10);
+#endif
+
+                    return () => new Subject("SUBJ1");
+                });
+
+                test.Given(getOldSubject =>
+                {
+                    oldSubject2 = getOldSubject();
+                    return () => new Subject("SUBJ2");
+                });
+
+                test.When(async subject =>
+                {
+                    whenSubject = subject;
+
+                    foreach (int key in Enumerable.Range(0, 1000))
+                    {
+#if NET45
+                        await Task.Delay(10);
+#else
+                        await TaskEx.Delay(10);
+#endif
+                        sideEffects.Add(key);
+                    }
+
+                    return "DONE";
+                });
+            }
+
+            [Fact]
+            public async void Then_it_should_execute_asynchronously()
+            {
+                await test.ExecuteGiven();
+                await test.ExecuteWhen();
+
+                sideEffects.Should().HaveCount(1000);
+            }
+
+            [Fact]
+            public async void Then_it_should_return_result()
+            {
+                await test.ExecuteGiven();
+                string result = await test.ExecuteWhen();
+                result.Should().Be("DONE");
+            }
+
+            [Fact]
+            public async void Then_it_should_have_subject_from_the_last_given()
+            {
+                Subject subject = await test.ExecuteGiven();
+                await test.ExecuteWhen();
+
+                subject.Should().NotBeNull();
+                subject.Value.Should().Be("SUBJ2");
+            }
+
+            [Fact]
+            public async void Then_the_first_given_should_receive_subject_factory_building_default_subject()
+            {
+                await test.ExecuteGiven();
+                await test.ExecuteWhen();
+
+                oldSubject1.Should().NotBeNull();
+                oldSubject1.Value.Should().Be(string.Empty);
+            }
+
+            [Fact]
+            public async void Then_the_second_given_should_receive_subject_factory_from_the_first_given()
+            {
+                await test.ExecuteGiven();
+                await test.ExecuteWhen();
+
+                oldSubject2.Should().NotBeNull();
+                oldSubject2.Value.Should().Be("SUBJ1");
+            }
+
+            [Fact]
+            public async void Then_the_when_should_receive_subject_from_the_last_given()
+            {
+                await test.ExecuteGiven();
+                await test.ExecuteWhen();
+
+                whenSubject.Should().NotBeNull();
+                whenSubject.Value.Should().Be("SUBJ2");
+            }
+        }
+
+        public class Subject
+        {
+            public Subject()
+                : this(string.Empty)
+            {
+
+            }
+
+            public Subject(string value)
+            {
+                Value = value;
+            }
+
+            public string Value { get; }
+        }
+    }
+}

--- a/Source/Core/Chill.Tests.Shared/AutoMotherSpecs.cs
+++ b/Source/Core/Chill.Tests.Shared/AutoMotherSpecs.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace Chill.Tests
 {
     [ChillContainer(typeof(AutofacNSubstituteChillContainer))]
-    public class AutoMotherSpecs : TestBase
+    public class AutoMotherSpecs : SyncTestBase
     {
         [Fact]
         public void Can_build_a_type_using_automother()

--- a/Source/Core/Chill.Tests.Shared/Chill.Tests.Shared.projitems
+++ b/Source/Core/Chill.Tests.Shared/Chill.Tests.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Chill.Tests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)AsyncTestSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AsyncSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AutoMotherSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CoreScenarios\AutofacChillContainerSpecs.cs" />

--- a/Source/Core/Chill.Tests.Shared/CoreScenarios/TestBaseSpecs.cs
+++ b/Source/Core/Chill.Tests.Shared/CoreScenarios/TestBaseSpecs.cs
@@ -7,7 +7,7 @@ using Xunit.Extensions;
 
 namespace Chill.Tests.CoreScenarios
 {
-    public abstract class TestBaseSpecs : TestBase
+    public abstract class TestBaseSpecs : SyncTestBase
     {
 
 


### PR DESCRIPTION
The existing Chill specs allow specifying async givens and whens but run them synchronously via blocking waits. However some test frameworks (for example, xUnit) do support really async specs without any blocking. This PR adds an experimental base class for such specs. That should avoid problems mentioned in #48.

Also only one base class is used for all the scenarios (with and without subject, with and without result). That solves #44.

@Erwinvandervalk, @dennisdoomen, what do you think?