### PR TITLE
Trigger deferred test on retrieving result

### DIFF
--- a/Source/Core/Chill.Shared/GivenSubject.cs
+++ b/Source/Core/Chill.Shared/GivenSubject.cs
@@ -20,7 +20,11 @@ namespace Chill
         /// </summary>
         protected TResult Result
         {
-            get { return result; }
+            get
+            {
+                TriggerTest(false);
+                return result;
+            }
         }
 
         /// <summary>

--- a/Source/Core/Chill.Tests.Shared/CoreScenarios/GivenSubjectSpecs.cs
+++ b/Source/Core/Chill.Tests.Shared/CoreScenarios/GivenSubjectSpecs.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Chill.Tests.TestSubjects;
+
 using FluentAssertions;
 using Xunit;
 
@@ -109,6 +110,19 @@ namespace Chill.Tests.CoreScenarios
 
                 return true;
             }
+        }
+    }
+
+    public class GivenSubjectResultSpecs : GivenSubject<object, string>
+    {
+        [Fact]
+        public void When_calling_when_deffered_then_whenaction_is_called_on_result()
+        {
+            string message = "";
+            Given(() => message += "given");
+            When(() => message += "when", deferedExecution: true);
+            message.Should().Be("given");
+            Result.Should().Be("givenwhen");
         }
     }
 


### PR DESCRIPTION
In our case we chill our selenium UI tests. As a feature a screenshot is created when the test fails. Currently this is only possible by including the given and when inside the actual test method (then) because when an exception occurs in the constructor it is not possible to catch it for building the screenshot.

Solution would be use a deffered test, but that is currently only possible when expecting an exception. This is now supported through the Result property which will execute the deferred test first.