### PR TITLE
Calling result for non-defered tests should not run test again

### DIFF
--- a/Source/Core/Chill.Shared/GivenSubject.cs
+++ b/Source/Core/Chill.Shared/GivenSubject.cs
@@ -22,7 +22,7 @@ namespace Chill
         {
             get
             {
-                TriggerTest(false);
+                EnsureTestTriggered(false);
                 return result;
             }
         }

--- a/Source/Core/Chill.Tests.Shared/CoreScenarios/GivenSubjectSpecs.cs
+++ b/Source/Core/Chill.Tests.Shared/CoreScenarios/GivenSubjectSpecs.cs
@@ -116,12 +116,22 @@ namespace Chill.Tests.CoreScenarios
     public class GivenSubjectResultSpecs : GivenSubject<object, string>
     {
         [Fact]
-        public void When_calling_when_deffered_then_whenaction_is_called_on_result()
+        public void When_calling_when_defered_then_whenaction_is_called_on_result()
         {
             string message = "";
             Given(() => message += "given");
             When(() => message += "when", deferedExecution: true);
             message.Should().Be("given");
+            Result.Should().Be("givenwhen");
+        }
+
+        [Fact]
+        public void When_calling_when_directly_then_whenaction_is_not_called_on_result()
+        {
+            string message = "";
+            Given(() => message += "given");
+            When(() => message += "when");
+            message.Should().Be("givenwhen");
             Result.Should().Be("givenwhen");
         }
     }


### PR DESCRIPTION
Version 2.4.2 introduced a test trigger for defered tests, but had a buggy side effect that non-defered tests were run twice (when accessing the `Result` property).

This has been fixed by first checking if the test was already executed.