### PR TITLE
Fix for incompatible plugin dependency versions

### DIFF
--- a/Source/Plugins/Chill.Autofac/.nuspec
+++ b/Source/Plugins/Chill.Autofac/.nuspec
@@ -18,7 +18,7 @@
     <dependencies>
       <group>
         <dependency id="Chill" version="[2.2,3.0)" />
-        <dependency id="Autofac" version="(,4.0)" />
+        <dependency id="Autofac" version="(3.0,4.0)" />
       </group>
     </dependencies>
 

--- a/Source/Plugins/Chill.AutofacFakeItEasy/.nuspec
+++ b/Source/Plugins/Chill.AutofacFakeItEasy/.nuspec
@@ -18,8 +18,8 @@
     <dependencies>
       <group>
         <dependency id="Chill" version="[2.2,3.0)" />
-        <dependency id="Autofac" version="[,4.0)" />
-        <dependency id="FakeItEasy" version="(,2.0)" />
+        <dependency id="Autofac" version="(3.0,4.0)" />
+        <dependency id="FakeItEasy" version="[1.10.0,2.0)" />
       </group>
     </dependencies>
 

--- a/Source/Plugins/Chill.AutofacNSubstitute/.nuspec
+++ b/Source/Plugins/Chill.AutofacNSubstitute/.nuspec
@@ -18,7 +18,7 @@
     <dependencies>
       <group>
         <dependency id="Chill" version="[2.2,3.0)" />
-        <dependency id="Autofac" version="[,4.0)" />
+        <dependency id="Autofac" version="(3.0,4.0)" />
         <dependency id="NSubstitute" version="(,2.0)" />
       </group>
     </dependencies>


### PR DESCRIPTION
When I try to get any Chill plugin packages that depends on _AutoFac_ or _FakeItEasy_; by default `-Lowest` dependency version within the defined range is downloaded. The imported code does not compile with downloaded lowest versions of _AutoFac_ and _FakeItEasy_.

With this PR, dependency range specified in the _nuspec_ files are corrected.