### PR TITLE
Deferred spelling correction

### DIFF
--- a/Source/Core/Chill.Net45.Tests/UnityChillContainerSpecs.cs
+++ b/Source/Core/Chill.Net45.Tests/UnityChillContainerSpecs.cs
@@ -25,7 +25,7 @@ namespace Chill.Tests.CoreScenarios
             [Fact]
             public void Subject_is_not_generated_by_nsubstitute()
             {
-                When(() => Subject.Received().DoSomething(), deferedExecution: true);
+                When(() => Subject.Received().DoSomething(), deferredExecution: true);
                 WhenAction.ShouldThrow<NotASubstituteException>();
             }
 

--- a/Source/Core/Chill.Shared/GivenSubject.cs
+++ b/Source/Core/Chill.Shared/GivenSubject.cs
@@ -7,7 +7,7 @@ namespace Chill
     /// BDD style test base class for tests that have a fixed subject and a fixed result. 
     /// The TSubject type defines the type of the subject, and the TResult defines the type of the result. 
     /// </summary>
-    /// <typeparam name="TSubject">The type of the subject</typeparam>esu
+    /// <typeparam name="TSubject">The type of the subject</typeparam>
     /// <typeparam name="TResult">The type of the result</typeparam>
     public abstract class GivenSubject<TSubject, TResult> : TestFor<TSubject>
         where TSubject : class
@@ -28,7 +28,7 @@ namespace Chill
         }
 
         /// <summary>
-        /// The action that triggers the test. Typically used in combination with deffered execution. 
+        /// The action that triggers the test. Typically used in combination with deferred execution. 
         /// </summary>
         public Func<TResult> WhenAction
         {
@@ -44,10 +44,10 @@ namespace Chill
         /// Records the action that will trigger the actual test
         /// </summary>
         /// <param name="whenFunc"></param>
-        /// <param name="deferedExecution">Should the test be executed immediately or be deffered?</param>
-        protected void When(Func<TResult> whenFunc, bool? deferedExecution = null)
+        /// <param name="deferredExecution">Should the test be executed immediately or be deferred?</param>
+        protected void When(Func<TResult> whenFunc, bool? deferredExecution = null)
         {
-            DefferedExecution = deferedExecution ?? DefferedExecution;
+            DefferedExecution = deferredExecution ?? DefferedExecution;
             EnsureSubject();
             if (WhenAction != null)
             {
@@ -63,10 +63,10 @@ namespace Chill
         /// Records the asynchronous action that will trigger the actual test
         /// </summary>
         /// <param name="whenFunc"></param>
-        /// <param name="deferedExecution">Should the test be executed immediately or be deffered?</param>
-        protected void When(Func<Task<TResult>> whenFunc, bool? deferedExecution = null)
+        /// <param name="deferredExecution">Should the test be executed immediately or be deferred?</param>
+        protected void When(Func<Task<TResult>> whenFunc, bool? deferredExecution = null)
         {
-            this.When(() => whenFunc.ExecuteInDefaultSynchronizationContext(), deferedExecution);
+            this.When(() => whenFunc.ExecuteInDefaultSynchronizationContext(), deferredExecution);
         }
 
         internal override void TriggerTest(bool expectExceptions)
@@ -105,7 +105,7 @@ namespace Chill
         private Action whenAction;
 
         /// <summary>
-        /// The action that triggers the test. Typically used in combination with deffered execution. 
+        /// The action that triggers the test. Typically used in combination with deferred execution. 
         /// </summary>
         public Action WhenAction
         {
@@ -121,10 +121,10 @@ namespace Chill
         /// Records the action that will trigger the actual test
         /// </summary>
         /// <param name="whenAction"></param>
-        /// <param name="deferedExecution">Should the test be executed immediately or be deffered?</param>
-        public void When(Action whenAction, bool? deferedExecution = null)
+        /// <param name="deferredExecution">Should the test be executed immediately or be deferred?</param>
+        public void When(Action whenAction, bool? deferredExecution = null)
         {
-            DefferedExecution = deferedExecution ?? DefferedExecution;
+            DefferedExecution = deferredExecution ?? DefferedExecution;
             EnsureContainer();
             if (WhenAction != null)
             {
@@ -142,10 +142,10 @@ namespace Chill
         /// Records the asynchronous action that will trigger the actual test
         /// </summary>
         /// <param name="whenActionAsync"></param>
-        /// <param name="deferedExecution">Should the test be executed immediately or be deffered?</param>
-        public void When(Func<Task> whenActionAsync, bool? deferedExecution = null)
+        /// <param name="deferredExecution">Should the test be executed immediately or be deferred?</param>
+        public void When(Func<Task> whenActionAsync, bool? deferredExecution = null)
         {
-            When(() => whenActionAsync.ExecuteInDefaultSynchronizationContext(), deferedExecution);
+            When(() => whenActionAsync.ExecuteInDefaultSynchronizationContext(), deferredExecution);
         }
 
         internal override void TriggerTest(bool expectExceptions)

--- a/Source/Core/Chill.Shared/GivenSubject.cs
+++ b/Source/Core/Chill.Shared/GivenSubject.cs
@@ -47,14 +47,14 @@ namespace Chill
         /// <param name="deferredExecution">Should the test be executed immediately or be deferred?</param>
         protected void When(Func<TResult> whenFunc, bool? deferredExecution = null)
         {
-            DefferedExecution = deferredExecution ?? DefferedExecution;
+            DeferredExecution = deferredExecution ?? DeferredExecution;
             EnsureSubject();
             if (WhenAction != null)
             {
                 throw new InvalidOperationException("When already defined");
             }
             whenAction = whenFunc;
-            if (!DefferedExecution)
+            if (!DeferredExecution)
             {
                 EnsureTestTriggered(false);
             }
@@ -124,14 +124,14 @@ namespace Chill
         /// <param name="deferredExecution">Should the test be executed immediately or be deferred?</param>
         public void When(Action whenAction, bool? deferredExecution = null)
         {
-            DefferedExecution = deferredExecution ?? DefferedExecution;
+            DeferredExecution = deferredExecution ?? DeferredExecution;
             EnsureContainer();
             if (WhenAction != null)
             {
                 throw new InvalidOperationException("When already defined");
             }
             this.whenAction = whenAction;
-            if (!DefferedExecution)
+            if (!DeferredExecution)
             {
                 EnsureTestTriggered(false);
             }

--- a/Source/Core/Chill.Shared/GivenWhenThen.cs
+++ b/Source/Core/Chill.Shared/GivenWhenThen.cs
@@ -46,14 +46,14 @@ namespace Chill
         /// <param name="deferredExecution">Should the test be executed immediately or be deferred?</param>
         protected void When(Func<TResult> whenFunc, bool? deferredExecution = null)
         {
-            DefferedExecution = deferredExecution ?? DefferedExecution;
+            DeferredExecution = deferredExecution ?? DeferredExecution;
             EnsureContainer();
             if (WhenAction != null)
             {
                 throw new InvalidOperationException("When already defined");
             }
             whenAction = whenFunc;
-            if (!this.DefferedExecution)
+            if (!this.DeferredExecution)
             {
                 EnsureTestTriggered(false);
             }
@@ -123,14 +123,14 @@ namespace Chill
         /// <param name="deferredExecution">Should the test be executed immediately or be deferred?</param>
         public void When(Action whenAction, bool? deferredExecution = null)
         {
-            DefferedExecution = deferredExecution ?? DefferedExecution;
+            DeferredExecution = deferredExecution ?? DeferredExecution;
             EnsureContainer();
             if (WhenAction != null)
             {
                 throw new InvalidOperationException("When already defined");
             }
             this.whenAction = whenAction;
-            if (!this.DefferedExecution)
+            if (!this.DeferredExecution)
             {
                 EnsureTestTriggered(false);
             }

--- a/Source/Core/Chill.Shared/GivenWhenThen.cs
+++ b/Source/Core/Chill.Shared/GivenWhenThen.cs
@@ -26,7 +26,7 @@ namespace Chill
         }
 
         /// <summary>
-        /// The action that triggers the actual test. This can be used in combination with deffered execution and fluent assertions 
+        /// The action that triggers the actual test. This can be used in combination with deferred execution and fluent assertions 
         /// to detect exceptions, if you don't wnat to use the <see cref="TestBase.CaughtException"/>
         /// </summary>
         public Func<TResult> WhenAction
@@ -43,10 +43,10 @@ namespace Chill
         /// Records the action that will trigger the actual test
         /// </summary>
         /// <param name="whenFunc"></param>
-        /// <param name="deferedExecution">Should the test be executed immediately or be deffered?</param>
-        protected void When(Func<TResult> whenFunc, bool? deferedExecution = null)
+        /// <param name="deferredExecution">Should the test be executed immediately or be deferred?</param>
+        protected void When(Func<TResult> whenFunc, bool? deferredExecution = null)
         {
-            DefferedExecution = deferedExecution ?? DefferedExecution;
+            DefferedExecution = deferredExecution ?? DefferedExecution;
             EnsureContainer();
             if (WhenAction != null)
             {
@@ -69,10 +69,10 @@ namespace Chill
         /// Records the asynchronous action that will trigger the actual test
         /// </summary>
         /// <param name="whenFunc"></param>
-        /// <param name="deferedExecution">Should the test be executed immediately or be deffered?</param>
-        protected void When(Func<Task<TResult>> whenFunc, bool? deferedExecution = null)
+        /// <param name="deferredExecution">Should the test be executed immediately or be deferred?</param>
+        protected void When(Func<Task<TResult>> whenFunc, bool? deferredExecution = null)
         {
-            this.When(() => whenFunc.ExecuteInDefaultSynchronizationContext(), deferedExecution);
+            this.When(() => whenFunc.ExecuteInDefaultSynchronizationContext(), deferredExecution);
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Chill
         private Action whenAction;
 
         /// <summary>
-        /// The action that triggers the actual test. This can be used in combination with deffered execution and fluent assertions 
+        /// The action that triggers the actual test. This can be used in combination with deferred execution and fluent assertions 
         /// to detect exceptions, if you don't wnat to use the <see cref="TestBase.CaughtException"/>
         /// </summary>
         public Action WhenAction
@@ -120,10 +120,10 @@ namespace Chill
         /// Records the action that will trigger the actual test
         /// </summary>
         /// <param name="whenAction"></param>
-        /// <param name="deferedExecution">Should the test be executed immediately or be deffered?</param>
-        public void When(Action whenAction, bool? deferedExecution = null)
+        /// <param name="deferredExecution">Should the test be executed immediately or be deferred?</param>
+        public void When(Action whenAction, bool? deferredExecution = null)
         {
-            DefferedExecution = deferedExecution ?? DefferedExecution;
+            DefferedExecution = deferredExecution ?? DefferedExecution;
             EnsureContainer();
             if (WhenAction != null)
             {
@@ -141,10 +141,10 @@ namespace Chill
         /// Records the asynchronous action that will trigger the actual test
         /// </summary>
         /// <param name="whenActionAsync"></param>
-        /// <param name="deferedExecution">Should the test be executed immediately or be deffered?</param>
-        public void When(Func<Task> whenActionAsync, bool? deferedExecution = null)
+        /// <param name="deferredExecution">Should the test be executed immediately or be deferred?</param>
+        public void When(Func<Task> whenActionAsync, bool? deferredExecution = null)
         {
-            this.When(() => whenActionAsync.ExecuteInDefaultSynchronizationContext(), deferedExecution);
+            this.When(() => whenActionAsync.ExecuteInDefaultSynchronizationContext(), deferredExecution);
         }
 
         internal override void TriggerTest(bool expectExceptions)

--- a/Source/Core/Chill.Shared/TestBase.cs
+++ b/Source/Core/Chill.Shared/TestBase.cs
@@ -18,8 +18,18 @@ namespace Chill
         /// <summary>
         /// Should the test execution start immediately on the When method or should execution be deferred until needed. 
         /// </summary>
-        protected bool DefferedExecution { get; set; }
-    
+        [Obsolete("Because of the typo and will be removed. Consider using DeferredExecution property instead.")]
+        protected bool DefferedExecution
+        {
+            get { return DeferredExecution; }
+            set { DeferredExecution = value; }
+        }
+
+        /// <summary>
+        /// Should the test execution start immediately on the When method or should execution be deferred until needed. 
+        /// </summary>
+        protected bool DeferredExecution { get; set; }
+
         private bool testTriggered;
         private bool containerInitialized;
         internal readonly IChillContainerInitializer ChillContainerInitializer;

--- a/Source/Core/Chill.Shared/TestBase.cs
+++ b/Source/Core/Chill.Shared/TestBase.cs
@@ -16,7 +16,7 @@ namespace Chill
     public abstract partial class TestBase : IDisposable
     {
         /// <summary>
-        /// Should the test execution start immediately on the When method or should execution be deffered until needed. 
+        /// Should the test execution start immediately on the When method or should execution be deferred until needed. 
         /// </summary>
         protected bool DefferedExecution { get; set; }
     
@@ -34,7 +34,7 @@ namespace Chill
 
         /// <summary>
         /// Any exception that might be thrown in the course of executing the When Method. Note, this property is often used
-        /// in conjunction with deffered excecution. 
+        /// in conjunction with deferred excecution. 
         /// </summary>
         protected Exception CaughtException
         {

--- a/Source/Core/Chill.Tests.Shared/AsyncSpecs.cs
+++ b/Source/Core/Chill.Tests.Shared/AsyncSpecs.cs
@@ -50,7 +50,7 @@ namespace Chill.Tests.Shared
 #endif
                         throw new ApplicationException();
                     },
-                    deferedExecution: true);
+                    deferredExecution: true);
             }
 
             [Fact]
@@ -80,7 +80,7 @@ namespace Chill.Tests.Shared
 #endif
                         throw new ApplicationException();
                     }),
-                    deferedExecution: true);
+                    deferredExecution: true);
             }
 
             [Fact]
@@ -112,7 +112,7 @@ namespace Chill.Tests.Shared
 #endif
                         throw new ApplicationException();
                     },
-                    deferedExecution: true);
+                    deferredExecution: true);
             }
 
             [Fact]
@@ -142,7 +142,7 @@ namespace Chill.Tests.Shared
 #endif
                         throw new ApplicationException();
                     }),
-                    deferedExecution: true);
+                    deferredExecution: true);
             }
 
             [Fact]

--- a/Source/Core/Chill.Tests.Shared/CoreScenarios/AutoFacNSubstituteSpecs.cs
+++ b/Source/Core/Chill.Tests.Shared/CoreScenarios/AutoFacNSubstituteSpecs.cs
@@ -20,7 +20,7 @@ namespace Chill.Tests
             [Fact]
             public void Subject_is_not_generated_by_nsubstitute()
             {
-                When(() => Subject.Received().DoSomething(), deferedExecution:true);
+                When(() => Subject.Received().DoSomething(), deferredExecution: true);
                 WhenAction.ShouldThrow<NotASubstituteException>();
             }
 

--- a/Source/Core/Chill.Tests.Shared/CoreScenarios/GivenSubjectSpecs.cs
+++ b/Source/Core/Chill.Tests.Shared/CoreScenarios/GivenSubjectSpecs.cs
@@ -53,18 +53,18 @@ namespace Chill.Tests.CoreScenarios
         }
 
         [Fact]
-        public void When_calling_when_deffered_then_whenaction_is_not_called_automatically()
+        public void When_calling_when_deferred_then_whenaction_is_not_called_automatically()
         {
             string message = "";
             Given(() => message += "given");
-            When(() => message += "when", deferedExecution: true);
+            When(() => message += "when", deferredExecution: true);
             message.Should().Be("given");
             WhenAction();
             message.Should().Be("givenwhen");
         }
 
         [Fact]
-        public void When_deffered_and_calling_when_then_whenaction_is_not_called_automatically()
+        public void When_deferred_and_calling_when_then_whenaction_is_not_called_automatically()
         {
             DefferedExecution = true;
             string message = "";
@@ -116,11 +116,11 @@ namespace Chill.Tests.CoreScenarios
     public class GivenSubjectResultSpecs : GivenSubject<object, string>
     {
         [Fact]
-        public void When_calling_when_defered_then_whenaction_is_called_on_result()
+        public void When_calling_when_deferred_then_whenaction_is_called_on_result()
         {
             string message = "";
             Given(() => message += "given");
-            When(() => message += "when", deferedExecution: true);
+            When(() => message += "when", deferredExecution: true);
             message.Should().Be("given");
             Result.Should().Be("givenwhen");
         }

--- a/Source/Core/Chill.Tests.Shared/CoreScenarios/GivenSubjectSpecs.cs
+++ b/Source/Core/Chill.Tests.Shared/CoreScenarios/GivenSubjectSpecs.cs
@@ -66,7 +66,7 @@ namespace Chill.Tests.CoreScenarios
         [Fact]
         public void When_deferred_and_calling_when_then_whenaction_is_not_called_automatically()
         {
-            DefferedExecution = true;
+            DeferredExecution = true;
             string message = "";
             Given(() => message += "given");
             When(() => message += "when");

--- a/Source/Core/Chill.Tests.Shared/StateBuilderSpecs.cs
+++ b/Source/Core/Chill.Tests.Shared/StateBuilderSpecs.cs
@@ -34,7 +34,7 @@ namespace Chill.Tests
         [Fact]
         public void When_deferring_execution_as_property_then_action_is_not_executed_immediately()
         {
-            DefferedExecution = true;
+            DeferredExecution = true;
             When(() => { throw new Exception(); });
         }
         

--- a/Source/Core/Chill.Tests.Shared/StateBuilderSpecs.cs
+++ b/Source/Core/Chill.Tests.Shared/StateBuilderSpecs.cs
@@ -26,13 +26,13 @@ namespace Chill.Tests
         }
 
         [Fact]
-        public void When_deffering_execution_then_action_is_not_executed_immediately()
+        public void When_deferring_execution_then_action_is_not_executed_immediately()
         {
-            When(() => { throw new Exception(); }, deferedExecution:true);
+            When(() => { throw new Exception(); }, deferredExecution:true);
         }
 
         [Fact]
-        public void When_deffering_execution_as_property_then_action_is_not_executed_immediately()
+        public void When_deferring_execution_as_property_then_action_is_not_executed_immediately()
         {
             DefferedExecution = true;
             When(() => { throw new Exception(); });
@@ -47,32 +47,32 @@ namespace Chill.Tests
         }
 
         [Fact]
-        public void When_exception_is_thrown_in_async_method_in_deffered_execution_expected_exception_is_filled()
+        public void When_exception_is_thrown_in_async_method_in_deferred_execution_expected_exception_is_filled()
         {
             Func<Task> whenActionASync = () => Task.Factory.StartNew(() => { throw new AbandonedMutexException(); });
-            When(whenActionASync, deferedExecution: true);
+            When(whenActionASync, deferredExecution: true);
             CaughtException.Should().BeOfType<AbandonedMutexException>();
         }
 
         [Fact]
-        public void When_exception_is_thrown_in_deffered_execution_expected_exception_is_filled()
+        public void When_exception_is_thrown_in_deferred_execution_expected_exception_is_filled()
         {
             Action whenActionASync = () => { throw new AbandonedMutexException(); };
-            When(whenActionASync, deferedExecution:true);
+            When(whenActionASync, deferredExecution:true);
             CaughtException.Should().BeOfType<AbandonedMutexException>();
         }
 
         [Fact]
-        public void When_deffering_execution_then_whenaction_can_be_used_to_test_for_exceptions()
+        public void When_deferring_execution_then_whenaction_can_be_used_to_test_for_exceptions()
         {
-            When(() => { throw new AbandonedMutexException(); }, deferedExecution: true);
+            When(() => { throw new AbandonedMutexException(); }, deferredExecution: true);
             WhenAction.ShouldThrow<AbandonedMutexException>();
         }
 
         [Fact]
         public void When_no_exception_is_thrown_but_expected_exception_is_used_then_caughtexceptoin_throws()
         {
-            When(() => { }, deferedExecution: true);
+            When(() => { }, deferredExecution: true);
             Action a = () =>
             {
                 Exception e = CaughtException;


### PR DESCRIPTION
@dennisdoomen instead of going for a rename for the property which is exposed to external, I introduced another one `DeferredExecution` and decorated the old one with `[Obsolete]`. The old one now remains as an unused member of the `TestBase` class and can be removed anytime you guys see fit.