### PR TITLE
Fix issue with multiple named objects returning only the first registered instance

### DIFF
--- a/Source/Core/Chill.Shared/TestBase.cs
+++ b/Source/Core/Chill.Shared/TestBase.cs
@@ -307,7 +307,7 @@ namespace Chill
         /// <returns></returns>
         public T UseThe<T>(T valueToSet, string named) where T : class
         {
-            return Container.Set<T>(valueToSet);
+            return Container.Set<T>(valueToSet, named);
         }
 
         /// <summary>

--- a/Source/Core/Chill.Tests.Shared/CoreScenarios/TestBaseSpecs.cs
+++ b/Source/Core/Chill.Tests.Shared/CoreScenarios/TestBaseSpecs.cs
@@ -44,6 +44,16 @@ namespace Chill.Tests.CoreScenarios
             The<AClass>().Name.Should().Be("abc");
         }
 
+        [Fact]
+        public void Can_get_different_named_objects()
+        {
+            UseThe(new TestSubjects.AClass("abc"), "abcName");
+            UseThe(new TestSubjects.AClass("def"), "defName");
+
+            TheNamed<TestSubjects.AClass>("abcName").Name.Should().Be("abc");
+            TheNamed<TestSubjects.AClass>("defName").Name.Should().Be("def");
+        }
+
 
         /// <summary>
         /// Testing if Dispose() is called on our subjects is tricky, because this happens AFTER a test, it's hard to test if it is actually called

--- a/Source/Plugins/Chill.Autofac/Content/Chill/AutofacChillContainer.cs
+++ b/Source/Plugins/Chill.Autofac/Content/Chill/AutofacChillContainer.cs
@@ -75,7 +75,7 @@ namespace Chill.Autofac
                         .As(new KeyedService(key, typeof(T)))
                         .InstancePerLifetimeScope().CreateRegistration());
             }
-            return Get<T>();
+            return Get<T>(key);
         }
 
 

--- a/Source/Plugins/Chill.Unity/Content/Chill/UnityChillContainer.cs
+++ b/Source/Plugins/Chill.Unity/Content/Chill/UnityChillContainer.cs
@@ -60,7 +60,7 @@ namespace Chill.Unity
             {
                 Container.RegisterInstance(key, valueToSet);
             }
-            return Get<T>();
+            return Get<T>(key);
         }
 
 


### PR DESCRIPTION
For multiple named objects with the same type,  the first registered entry was returned when retrieving the second registered object. This has been fixed by passing in the name to the target container.