### PR TITLE
Autofac plug-ins support Autofac versions 4.*

### DIFF
--- a/Source/Core/Chill.Net40.Tests/Chill.Net40.Tests.csproj
+++ b/Source/Core/Chill.Net40.Tests/Chill.Net40.Tests.csproj
@@ -43,7 +43,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac">
+    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da">
       <HintPath>..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="FakeItEasy">

--- a/Source/Core/Chill.Net45.Tests/Chill.Net45.Tests.csproj
+++ b/Source/Core/Chill.Net45.Tests/Chill.Net45.Tests.csproj
@@ -36,9 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da">
+      <HintPath>..\..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="FakeItEasy, Version=1.24.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Core/Chill.Net45.Tests/packages.config
+++ b/Source/Core/Chill.Net45.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.5.2" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
   <package id="AutoFixture" version="3.21.0" targetFramework="net45" />
   <package id="FakeItEasy" version="1.24.0" targetFramework="net45" />
   <package id="FluentAssertions" version="3.2.1" targetFramework="net45" />

--- a/Source/Examples/Chill.Examples.Tests/Chill.Examples.Tests.csproj
+++ b/Source/Examples/Chill.Examples.Tests/Chill.Examples.Tests.csproj
@@ -36,9 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da">
+      <HintPath>..\..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="FluentAssertions, Version=3.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Source/Examples/Chill.Examples.Tests/packages.config
+++ b/Source/Examples/Chill.Examples.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.5.2" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
   <package id="AutoFixture" version="3.21.0" targetFramework="net45" />
   <package id="FluentAssertions" version="3.2.1" targetFramework="net45" />
   <package id="NSubstitute" version="1.7.2.0" targetFramework="net45" />

--- a/Source/Plugins/Chill.Autofac/.nuspec
+++ b/Source/Plugins/Chill.Autofac/.nuspec
@@ -18,7 +18,7 @@
     <dependencies>
       <group>
         <dependency id="Chill" version="[2.2,3.0)" />
-        <dependency id="Autofac" version="(3.0,4.0)" />
+        <dependency id="Autofac" version="(3.0,5.0)" />
       </group>
     </dependencies>
 

--- a/Source/Plugins/Chill.AutofacFakeItEasy/.nuspec
+++ b/Source/Plugins/Chill.AutofacFakeItEasy/.nuspec
@@ -18,7 +18,7 @@
     <dependencies>
       <group>
         <dependency id="Chill" version="[2.2,3.0)" />
-        <dependency id="Autofac" version="(3.0,4.0)" />
+        <dependency id="Autofac" version="(3.0,5.0)" />
         <dependency id="FakeItEasy" version="[1.10.0,2.0)" />
       </group>
     </dependencies>

--- a/Source/Plugins/Chill.AutofacNSubstitute/.nuspec
+++ b/Source/Plugins/Chill.AutofacNSubstitute/.nuspec
@@ -18,7 +18,7 @@
     <dependencies>
       <group>
         <dependency id="Chill" version="[2.2,3.0)" />
-        <dependency id="Autofac" version="(3.0,4.0)" />
+        <dependency id="Autofac" version="(3.0,5.0)" />
         <dependency id="NSubstitute" version="(,2.0)" />
       </group>
     </dependencies>


### PR DESCRIPTION
The changes made in Autofac 4.* do not affect the plug-ins. So we can just update Autofac version in the specs.